### PR TITLE
Fix preview

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,7 +26,7 @@ class Post < Crowdblog::Post
   def short_description
     description = ""
     paragraphs = body.split("\n")
-    paragraphs.cycle do |p|
+    paragraphs.each do |p|
       description << p << "\n"
       break if description.size > SHORT_DESCRIPTION_SIZE
     end


### PR DESCRIPTION
- Short description takes up to 500 characters from the post.body but,
  if body size is lesser than that limit, short_description keeps
  repeating the words until size is completed
