### PR TITLE
[#85929984] Hide mobile menu on desktop view of a post

### DIFF
--- a/app/assets/stylesheets/modules/categories.scss
+++ b/app/assets/stylesheets/modules/categories.scss
@@ -44,6 +44,12 @@
       display: block !important;
     }
   }
+
+  .categories-mobile {
+    display: none;
+    @include mq-tablet() { display: block; }
+  }
+
   .categories-select {
     background-color: $home-color;
     border: none;


### PR DESCRIPTION
## Description

- Hides mobile menu on desktop view of a post.

![Image of mobile menu](https://s3.amazonaws.com/prod.tracker2/resource/40594508/Screen%20Shot%202015-01-12%20at%2012.46.52%20PM.png?AWSAccessKeyId=AKIAIKWOAN6H4H3QMJ6Q&Expires=1421090735&Signature=ndoK0j7xy1aryQtIxz7DYk2cCYA%3D)